### PR TITLE
Dashboard revenue chart dates are backwards on the x-axis

### DIFF
--- a/apps/guard/app/(dashboard)/@revenue/RevenueChart.tsx
+++ b/apps/guard/app/(dashboard)/@revenue/RevenueChart.tsx
@@ -73,7 +73,7 @@ const RevenueChart = ({ period, data }: RevenueChartProps) => {
         categories:
           data[0]?.data
             .map((datum) => moment(+datum.label).format(getDateFormat(period)))
-            .toReversed() ?? [],
+            .reverse() ?? [],
       },
       theme: {
         mode: theme.palette.mode,
@@ -110,7 +110,7 @@ const RevenueChart = ({ period, data }: RevenueChartProps) => {
               +getDecimalString(datum.amount, tokenData.title.decimals),
           ),
         }))
-        .toReversed(),
+        .reverse(),
     [data],
   );
 

--- a/apps/watcher/app/(home)/@revenue/RevenueChart.tsx
+++ b/apps/watcher/app/(home)/@revenue/RevenueChart.tsx
@@ -74,7 +74,7 @@ const RevenueChart = ({ period, data }: RevenueChartProps) => {
         categories:
           data[0]?.data
             .map((datum) => moment(+datum.label).format(getDateFormat(period)))
-            .toReversed() ?? [],
+            .reverse() ?? [],
       },
       theme: {
         mode: theme.palette.mode,
@@ -103,7 +103,7 @@ const RevenueChart = ({ period, data }: RevenueChartProps) => {
 
   const apexChartSeries = useMemo(
     () =>
-      data.toReversed().map((tokenData) => ({
+      data.reverse().map((tokenData) => ({
         name: tokenData.title.name,
         data: tokenData.data.map(
           (datum) => +getDecimalString(datum.amount, tokenData.title.decimals),


### PR DESCRIPTION
Closes #3 

Attempts to reverse the revenue columns and dates to go from oldest->newest going left->right. 

It is currently incorrectly newest columns left, oldest date left.