### PR TITLE
fix: use Id component for txId display in watcher actions (#9)

### DIFF
--- a/apps/watcher/src/app/actions/@form/lock/page.tsx
+++ b/apps/watcher/src/app/actions/@form/lock/page.tsx
@@ -7,7 +7,7 @@ import {
   AlertCard,
   AlertProps,
   ApiKeyModalWarning,
-  Link,
+  Id,
   Stack,
   SubmitButton,
   Typography,
@@ -111,12 +111,11 @@ const LockForm = () => {
           message: (
             <>
               Lock operation is in progress. Wait for tx [
-              <Link
-                target="_blank"
+              <Id
+                id={response.txId}
+                indicator="middle"
                 href={getTxURL(NETWORKS.ergo.key, response.txId)}
-              >
-                {response.txId}
-              </Link>
+              />
               ] to be confirmed by some blocks, so your new permits will be
               activated.
             </>

--- a/apps/watcher/src/app/actions/@form/unlock/page.tsx
+++ b/apps/watcher/src/app/actions/@form/unlock/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import Link from 'next/link';
 import { useMemo, useState, useEffect, ReactNode } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 
 import {
   AlertCard,
   AlertProps,
+  Id,
   SubmitButton,
   useApiKey,
   ApiKeyModalWarning,
@@ -133,12 +133,11 @@ const UnlockForm = () => {
           message: (
             <>
               Unlock operation is in progress. Wait for tx [
-              <Link
-                target="_blank"
-                href={getTxURL(NETWORKS.ergo.key, response.txId) ?? '/'}
-              >
-                {response.txId}
-              </Link>
+              <Id
+                id={response.txId}
+                indicator="middle"
+                href={getTxURL(NETWORKS.ergo.key, response.txId)}
+              />
               ] to be confirmed by some blocks.
             </>
           ),

--- a/apps/watcher/src/app/actions/@form/withdraw/page.tsx
+++ b/apps/watcher/src/app/actions/@form/withdraw/page.tsx
@@ -20,7 +20,6 @@ import {
   TextField,
   useApiKey,
   ApiKeyModalWarning,
-  Link,
   Stack,
 } from '@rosen-bridge/ui-kit';
 import { NETWORKS, TOKEN_NAME_PLACEHOLDER } from '@rosen-ui/constants';
@@ -145,12 +144,11 @@ const WithdrawForm = () => {
           message: (
             <>
               Withdrawal is successful. Wait for tx [
-              <Link
-                target="_blank"
-                href={getTxURL(NETWORKS.ergo.key, response.txId) ?? ''}
-              >
-                {response.txId}
-              </Link>
+              <Id
+                id={response.txId}
+                indicator="middle"
+                href={getTxURL(NETWORKS.ergo.key, response.txId)}
+              />
               ] to be confirmed.
             </>
           ),


### PR DESCRIPTION
Closes #9

## Changes

Replaces raw `{response.txId}` text wrapped in `<Link>` with the `<Id>` component across all 3 watcher action forms (lock, unlock, withdraw).

### What this does:
- Displays txIds truncated (first 10 + `...` + last 8 characters) using `<Id indicator="middle">`
- Links to the Ergo block explorer via `getTxURL(NETWORKS.ergo.key, response.txId)` passed as `href` to `<Id>`
- `target="_blank"` and `rel="noopener noreferrer"` are handled internally by the `<Id>` component
- Full txId is visible on hover (tooltip)

### Per-file changes:
- **lock/page.tsx** — Added `Id` import, removed unused `Link` import, replaced `<Link>` with `<Id>`
- **unlock/page.tsx** — Removed `next/link` import, added `Id` to ui-kit import, replaced `<Link>` with `<Id>`
- **withdraw/page.tsx** — Removed unused `Link` import (`Id` was already imported), replaced `<Link>` with `<Id>`

### Notes:
- Dropped `?? '/'` and `?? ''` fallbacks on `getTxURL()` in unlock and withdraw — the `Id` component's `href` is optional, so `undefined` gracefully renders plain text without a broken link
- Follows the existing `<Id indicator="middle">` pattern already used in `withdraw/page.tsx` for token IDs