### PR TITLE
chore: fix lint-staged knip workspace path on Windows

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -21,8 +21,8 @@ const perPackage = (resolver) => (files) => {
 };
 
 const getKnipCommand = (dir) => {
-  const posixRelative = path.posix.relative(process.cwd(), dir);
-  return `knip --dependencies --workspace ${posixRelative}`;
+  const relative = path.relative(process.cwd(), dir).split(path.sep).join('/');
+  return `knip --dependencies --workspace ${relative}`;
 };
 
 const runKnipConditional = (files) => {


### PR DESCRIPTION
## Summary

`getKnipCommand` in `.lintstagedrc.mjs` calls `path.posix.relative(process.cwd(), dir)`, but on Windows `process.cwd()` is a Windows-absolute path (e.g. `C:\\path\\to\\repo`). `path.posix.relative` treats its inputs as POSIX paths, so the mix produces a mangled relative that knip can't resolve to a workspace.

Use `path.relative(...)` (platform-aware) and then convert separators to `/` so knip gets a proper POSIX-style workspace path on every OS.

Split out of #19 per review — this is a Windows-only dev-tooling fix and has nothing to do with the Firo Bridge Expansion Kit.

## Test plan

- [ ] `lint-staged` runs cleanly on macOS / Linux (no behavior change: `path.relative` and `path.posix.relative` return the same string on POSIX).
- [ ] On Windows, `npm run lint-staged` resolves the knip `--workspace` argument correctly for a package under `packages/` or `apps/`.