### PR TITLE
fix: validate withdrawal address in watcher (#13)

### DIFF
--- a/apps/watcher/next.config.js
+++ b/apps/watcher/next.config.js
@@ -8,6 +8,18 @@ const nextConfig = {
     unoptimized: true,
   },
   output: 'export',
+  webpack: function (config) {
+    config.experiments = {
+      ...config.experiments,
+      asyncWebAssembly: true,
+      syncWebAssembly: true,
+      layers: true,
+    };
+    // Required for `output: 'export'` — ensures the .wasm file lands in
+    // the static assets output (so Next's static export copies it into out/).
+    config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm';
+    return config;
+  },
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/apps/watcher/package.json
+++ b/apps/watcher/package.json
@@ -25,6 +25,7 @@
     "@rosen-ui/constants": "^1.0.0",
     "@rosen-ui/swr-helpers": "^0.2.2",
     "@rosen-ui/utils": "^1.0.3",
+    "ergo-lib-wasm-browser": "^0.24.1",
     "lodash-es": "^4.17.21",
     "moment": "^2.29.4",
     "next": "^15.5.12",

--- a/apps/watcher/src/app/actions/@form/withdraw/page.tsx
+++ b/apps/watcher/src/app/actions/@form/withdraw/page.tsx
@@ -35,6 +35,7 @@ import {
   ApiWithdrawRequestBody,
   ApiWithdrawResponse,
 } from '@/types/api';
+import { validateErgoAddress } from '@/utils/validateErgoAddress';
 
 import { ConfirmationModal } from '../../ConfirmationModal';
 import {
@@ -94,14 +95,32 @@ const WithdrawForm = () => {
       amount: '',
     },
   });
-  const { handleSubmit, control, resetField, register, watch, formState } =
-    formMethods;
+  const { handleSubmit, control, resetField, watch, formState } = formMethods;
 
   const formData = watch();
 
   const { field: tokenIdField } = useController({
     control,
     name: 'tokenId',
+  });
+
+  const { field: addressField } = useController({
+    control,
+    name: 'address',
+    rules: {
+      validate: async (value) => {
+        try {
+          if (!value) {
+            return 'Address cannot be empty';
+          }
+          const isValid = await validateErgoAddress(value);
+          if (isValid) return;
+          return 'Invalid Address';
+        } catch {
+          return 'Something went wrong! please try again';
+        }
+      },
+    },
   });
 
   const selectedToken = useMemo(
@@ -198,9 +217,7 @@ const WithdrawForm = () => {
     <TextField
       label="Address"
       disabled={disabled}
-      {...register('address', {
-        required: 'Address is required',
-      })}
+      {...addressField}
       error={!!formMethods.formState.errors.address}
       helperText={
         formMethods.formState.isValidating ? (
@@ -210,6 +227,7 @@ const WithdrawForm = () => {
         )
       }
       onBlur={(e) => {
+        addressField.onBlur(); // preserve RHF touched-state tracking
         const trimmed = e.target.value.trim();
         formMethods.setValue('address', trimmed, {
           shouldDirty: true,

--- a/apps/watcher/src/utils/validateErgoAddress.ts
+++ b/apps/watcher/src/utils/validateErgoAddress.ts
@@ -1,0 +1,23 @@
+/**
+ * Validates an Ergo address (mainnet or testnet) using ergo-lib-wasm-browser.
+ * Lazy-loads the WASM module on first invocation to keep the initial bundle small.
+ *
+ * Approximates the validation behavior of @rosen-bridge/address-codec used by
+ * the Rosen app, adapted for browser execution (Watcher has no server boundary).
+ * Network-agnostic: accepts both mainnet and testnet Ergo addresses.
+ *
+ * @param address - The base58-encoded Ergo address to validate.
+ * @returns true if the address is a valid Ergo address (mainnet or testnet),
+ *          false otherwise.
+ */
+export const validateErgoAddress = async (
+  address: string,
+): Promise<boolean> => {
+  try {
+    const { Address } = await import('ergo-lib-wasm-browser');
+    Address.from_base58(address);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,6 +257,7 @@
         "@rosen-ui/constants": "^1.0.0",
         "@rosen-ui/swr-helpers": "^0.2.2",
         "@rosen-ui/utils": "^1.0.3",
+        "ergo-lib-wasm-browser": "^0.24.1",
         "lodash-es": "^4.17.21",
         "moment": "^2.29.4",
         "next": "^15.5.12",
@@ -498,7 +499,6 @@
       "version": "7.26.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1652,6 +1652,7 @@
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -1684,6 +1685,7 @@
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -1759,6 +1761,7 @@
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -2410,6 +2413,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -2428,7 +2432,8 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ethersproject/sha2": {
       "version": "5.8.0",
@@ -2455,7 +2460,8 @@
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -3410,7 +3416,6 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -4014,7 +4019,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4110,6 +4114,7 @@
       "version": "1.1.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -4119,6 +4124,7 @@
       "version": "1.1.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
@@ -4131,6 +4137,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -4142,6 +4149,7 @@
       "version": "3.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5918,8 +5926,7 @@
     },
     "node_modules/@rosen-bridge/extended-typeorm/node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@rosen-bridge/extended-typeorm/node_modules/typeorm": {
       "version": "0.3.26",
@@ -6672,7 +6679,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6872,6 +6878,7 @@
       "resolved": "https://registry.npmjs.org/@sats-connect/core/-/core-0.17.1.tgz",
       "integrity": "sha512-HYEU3+739nGgoUU0RlMwu7YXQOLaFhDiob31U8+Gr8aY4ezFskpqaFZqIHoRvkIrEhjT09PKzX/hh31Mm1NQZg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "axios": "1.13.5",
         "bitcoin-address-validation": "3.0.0",
@@ -6888,6 +6895,7 @@
       "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
       "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -6898,6 +6906,7 @@
       "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-3.0.0.tgz",
       "integrity": "sha512-R1X1c9EdgjgjTpjshjk5e16TbgF7HYasxBcu7l5ScWMxVs53845vMUg5PvnQ/R/3h8Grly6Y52DgH6/77gazLQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base58-js": "^3.0.2",
         "bech32": "^2.0.0",
@@ -7507,6 +7516,7 @@
       "version": "1.1.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -7668,14 +7678,14 @@
     "node_modules/@types/node": {
       "version": "22.18.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -7773,7 +7783,6 @@
       "version": "8.44.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.1",
         "@typescript-eslint/types": "8.44.1",
@@ -8814,12 +8823,14 @@
     },
     "node_modules/@yr/monotone-cubic-spline": {
       "version": "1.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/abitype": {
       "version": "1.0.6",
@@ -8847,7 +8858,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8871,6 +8881,7 @@
       "version": "6.0.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -8893,6 +8904,7 @@
       "version": "3.1.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -9045,7 +9057,8 @@
     "node_modules/aproba": {
       "version": "2.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -9282,7 +9295,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -9405,6 +9417,7 @@
     "node_modules/bindings": {
       "version": "1.5.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -9443,6 +9456,7 @@
     "node_modules/bl": {
       "version": "4.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -9466,6 +9480,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -9584,7 +9599,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -9658,7 +9672,6 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -9678,6 +9691,7 @@
       "version": "15.3.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
@@ -9706,6 +9720,7 @@
       "version": "6.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -9717,6 +9732,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -9728,6 +9744,7 @@
       "version": "3.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9741,7 +9758,8 @@
     "node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
@@ -9945,6 +9963,7 @@
     "node_modules/chownr": {
       "version": "2.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9966,6 +9985,7 @@
       "version": "2.2.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10154,6 +10174,7 @@
       "version": "1.1.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -10226,11 +10247,13 @@
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cookie-es": {
       "version": "1.2.2",
@@ -10247,6 +10270,7 @@
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -10464,6 +10488,7 @@
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -10540,7 +10565,8 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -10689,7 +10715,6 @@
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.17.tgz",
       "integrity": "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
@@ -10749,8 +10774,7 @@
     },
     "node_modules/embla-carousel": {
       "version": "8.5.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.5.2",
@@ -10895,9 +10919,16 @@
       "version": "2.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/ergo-lib-wasm-browser": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/ergo-lib-wasm-browser/-/ergo-lib-wasm-browser-0.24.1.tgz",
+      "integrity": "sha512-iPfh2e/ZtGWZo0h2rljBaJZPJa2Z2vTXBJtSyieH4qU/zE+5Ix/PWRBK9HLqr6tvS16/4ACeynMZd1/4uftZHQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/ergo-lib-wasm-nodejs": {
       "version": "0.24.1",
@@ -10906,7 +10937,8 @@
     "node_modules/err-code": {
       "version": "2.0.3",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -11576,7 +11608,6 @@
       "version": "9.36.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11773,7 +11804,6 @@
       "version": "2.31.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -12137,7 +12167,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -12205,8 +12234,7 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
@@ -12268,6 +12296,7 @@
     "node_modules/expand-template": {
       "version": "2.0.3",
       "license": "(MIT OR WTFPL)",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12426,7 +12455,8 @@
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -12440,7 +12470,8 @@
     },
     "node_modules/find-root": {
       "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -12574,7 +12605,8 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -12591,6 +12623,7 @@
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -12601,7 +12634,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -12752,12 +12786,14 @@
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glob": {
       "version": "7.1.7",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12949,7 +12985,8 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -12989,13 +13026,15 @@
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
     },
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -13010,6 +13049,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -13034,6 +13074,7 @@
       "version": "5.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -13156,6 +13197,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13163,12 +13205,14 @@
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -13180,7 +13224,8 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -13199,6 +13244,7 @@
       "version": "9.0.5",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -13210,7 +13256,8 @@
     "node_modules/ip-address/node_modules/sprintf-js": {
       "version": "1.1.3",
       "license": "BSD-3-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -13464,7 +13511,8 @@
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -13894,7 +13942,6 @@
       "version": "2.6.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -13944,7 +13991,8 @@
     "node_modules/jsbn": {
       "version": "1.1.0",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -14486,6 +14534,7 @@
       "version": "9.1.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
         "cacache": "^15.2.0",
@@ -14512,6 +14561,7 @@
       "version": "6.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14522,7 +14572,8 @@
     "node_modules/make-fetch-happen/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -14650,6 +14701,7 @@
     "node_modules/minipass": {
       "version": "3.3.6",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14661,6 +14713,7 @@
       "version": "1.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -14672,6 +14725,7 @@
       "version": "1.4.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
@@ -14688,6 +14742,7 @@
       "version": "1.0.5",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -14699,6 +14754,7 @@
       "version": "1.2.4",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -14710,6 +14766,7 @@
       "version": "1.0.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -14719,11 +14776,13 @@
     },
     "node_modules/minipass/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -14734,11 +14793,13 @@
     },
     "node_modules/minizlib/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mlly": {
       "version": "1.8.0",
@@ -14817,7 +14878,8 @@
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -14842,6 +14904,7 @@
       "version": "0.6.3",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14919,6 +14982,7 @@
     "node_modules/node-abi": {
       "version": "3.77.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -14928,7 +14992,8 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -14958,6 +15023,7 @@
       "version": "8.4.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -15003,6 +15069,7 @@
       "version": "3.0.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -15014,12 +15081,14 @@
     "node_modules/node-gyp/node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-gyp/node_modules/gauge": {
       "version": "4.0.4",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.3",
@@ -15038,6 +15107,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15046,6 +15116,7 @@
       "version": "6.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
@@ -15060,6 +15131,7 @@
       "version": "3.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -15074,6 +15146,7 @@
       "version": "4.2.3",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -15105,6 +15178,7 @@
       "version": "5.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -15698,6 +15772,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -15885,6 +15960,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15951,7 +16027,6 @@
     "node_modules/pg": {
       "version": "8.11.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -16201,6 +16276,7 @@
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -16234,7 +16310,6 @@
       "version": "3.6.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16270,12 +16345,14 @@
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -16600,6 +16677,7 @@
     "node_modules/rc": {
       "version": "1.2.8",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -16613,6 +16691,7 @@
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16622,7 +16701,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16643,7 +16721,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16732,7 +16809,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -16910,6 +16986,7 @@
       "version": "0.12.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -17479,7 +17556,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -17498,6 +17576,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -17536,6 +17615,7 @@
       "version": "4.2.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -17598,7 +17678,6 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -17672,6 +17751,7 @@
       "version": "2.8.5",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -17685,6 +17765,7 @@
       "version": "6.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
@@ -17706,6 +17787,7 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17787,6 +17869,7 @@
       "version": "8.0.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.1.1"
       },
@@ -18145,6 +18228,7 @@
     "node_modules/svg.draggable.js": {
       "version": "2.2.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg.js": "^2.0.1"
       },
@@ -18155,6 +18239,7 @@
     "node_modules/svg.easing.js": {
       "version": "2.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg.js": ">=2.3.x"
       },
@@ -18165,6 +18250,7 @@
     "node_modules/svg.filter.js": {
       "version": "2.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg.js": "^2.2.5"
       },
@@ -18174,11 +18260,13 @@
     },
     "node_modules/svg.js": {
       "version": "2.7.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/svg.pathmorphing.js": {
       "version": "0.1.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg.js": "^2.4.0"
       },
@@ -18189,6 +18277,7 @@
     "node_modules/svg.resize.js": {
       "version": "1.4.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg.js": "^2.6.5",
         "svg.select.js": "^2.1.2"
@@ -18200,6 +18289,7 @@
     "node_modules/svg.resize.js/node_modules/svg.select.js": {
       "version": "2.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg.js": "^2.2.5"
       },
@@ -18210,6 +18300,7 @@
     "node_modules/svg.select.js": {
       "version": "3.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg.js": "^2.6.5"
       },
@@ -18222,7 +18313,6 @@
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
       "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3",
         "use-sync-external-store": "^1.6.0"
@@ -18242,6 +18332,7 @@
     "node_modules/tar": {
       "version": "6.2.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -18257,6 +18348,7 @@
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -18266,11 +18358,13 @@
     },
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -18285,6 +18379,7 @@
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18292,6 +18387,7 @@
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -18301,7 +18397,8 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/term-size": {
       "version": "2.2.1",
@@ -18441,7 +18538,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18545,7 +18641,8 @@
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
       "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -18648,6 +18745,7 @@
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -18752,7 +18850,6 @@
     "node_modules/typescript": {
       "version": "5.8.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18811,6 +18908,7 @@
       "version": "1.1.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "unique-slug": "^2.0.0"
       }
@@ -18819,6 +18917,7 @@
       "version": "2.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       }
@@ -18991,7 +19090,6 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -19032,7 +19130,6 @@
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
       "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": ">=5"
       },
@@ -19762,7 +19859,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19870,11 +19966,28 @@
         }
       }
     },
+    "node_modules/vite-node/node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -20481,7 +20594,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20520,7 +20632,6 @@
       "version": "7.2.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -20588,6 +20699,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/vscode-uri": {
@@ -20740,6 +20869,7 @@
       "version": "1.1.5",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -20747,12 +20877,14 @@
     "node_modules/wide-align/node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -20761,6 +20893,7 @@
       "version": "4.2.3",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -20773,7 +20906,6 @@
     "node_modules/winston": {
       "version": "3.18.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",
@@ -20930,7 +21062,6 @@
     "node_modules/ws": {
       "version": "7.5.10",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -21383,7 +21514,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21444,7 +21574,6 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
Fixes #13.

## Changes

- Adds `ergo-lib-wasm-browser` (^0.24.1) to `apps/watcher` dependencies
- Adds webpack/WASM configuration to `apps/watcher/next.config.js` (mirrors the `experiments` block from `apps/rosen/next.config.js`, plus `output.webassemblyModuleFilename` needed for `output: 'export'`)
- Adds `apps/watcher/src/utils/validateErgoAddress.ts` — a browser-side Ergo address validator that lazy-loads the WASM module on first use
- Refactors the address field in `apps/watcher/src/app/actions/@form/withdraw/page.tsx` from `register('address', { required })` to `useController` with an async `validate` rule, mirroring the pattern in `apps/rosen/src/hooks/useBridgeForm.ts`

## Validation behavior

The validator uses `Address.from_base58()` from `ergo-lib-wasm-browser`, which accepts both mainnet and testnet Ergo addresses. The issue specifies "an Ergo address" (not "a mainnet Ergo address"), and a Watcher operator may be running a testnet deployment — restricting to mainnet would break testnet operators.

Error messages mirror the Rosen app's `useBridgeForm` exactly:
- Empty input: `"Address cannot be empty"` (intentional change from the previous `"Address is required"` to match Rosen)
- Invalid address: `"Invalid Address"`
- Unexpected error during validation: `"Something went wrong! please try again"`

## Verification

- `npm run build` for `apps/watcher` succeeds; the `.wasm` chunk is emitted to `out/_next/static/wasm/`
- The WASM file is served with `Content-Type: application/wasm` and HTTP 200 from a static-server smoke test
- No new TypeScript errors introduced (verified by comparing `npm run type-check` output against the pre-PR baseline)

## Notes for reviewers

- This PR is independent of #8 and can land in either order. Both PRs touch `apps/watcher/next.config.js` but in non-overlapping ways.
- CI may show pre-existing type-check failures in `apps/watcher/src/app/App.tsx` until #8 merges — those errors exist on the current `dev` branch and are exactly what #8 fixes. They are not introduced by this PR.
- WASM bundle adds ~2.5 MB; lazy-loaded on first address validation, kept out of the initial page bundle.